### PR TITLE
Add fitlering by prefix option in check-cloudwatch-alarms.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-cloudwatch-alarms.rb`: `--name-prefix`/`-p` option added to filter alarm names by a prefix. (@boutetnico)
+
 ## [18.5.0] - 2020-01-28
 ### Changed
 - `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same. (@swibowo)

--- a/bin/check-cloudwatch-alarms.rb
+++ b/bin/check-cloudwatch-alarms.rb
@@ -16,6 +16,7 @@
 #   gem: sensu-plugin
 #
 # USAGE:
+#   ./check-cloudwatch-alarms --name-prefix "staging"
 #   ./check-cloudwatch-alarms --exclude-alarms "CPUAlarmLow"
 #   ./check-cloudwatch-alarms --region eu-west-1 --exclude-alarms "CPUAlarmLow"
 #
@@ -46,6 +47,12 @@ class CloudWatchCheck < Sensu::Plugin::Check::CLI
          long: '--state STATE',
          default: 'ALARM'
 
+  option :name_prefix,
+         description: 'Alarm name prefix',
+         short: '-p NAME_PREFIX',
+         long: '--name-prefix NAME_PREFIX',
+         default: ''
+
   option :exclude_alarms,
          description: 'Exclude alarms',
          short: '-e EXCLUDE_ALARMS',
@@ -57,6 +64,11 @@ class CloudWatchCheck < Sensu::Plugin::Check::CLI
     client = Aws::CloudWatch::Client.new
 
     options = { state_value: config[:state] }
+
+    unless config[:name_prefix].empty?
+      options[:alarm_name_prefix] = config[:name_prefix]
+    end
+
     alarms = client.describe_alarms(options).metric_alarms
 
     if alarms.empty?


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Add a new option `--name-prefix`  / `-p` allowing to limit alarms considered in the check by a given prefix. The prefix works with the alarm name.

Here is an example:

```
ruby check-cloudwatch-alarms.rb  -s OK
CloudWatchCheck CRITICAL: 2 in 'OK' state: prod-alarm,staging-alarm
```

```
ruby check-cloudwatch-alarms.rb  -s OK -p staging
CloudWatchCheck CRITICAL: 1 in 'OK' state: staging-alarm
```

#### Known Compatibility Issues

None